### PR TITLE
Use hosts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For blocked domains we respond with 127.0.0.1. Use --nofilter to disable.
   The filter files are /etc/fdns/adblocker and /etc/fdns/trackers.
 These are regular text file, you can modify them, or even delete them.
 You can also add your own list in /etc/fdns/hosts.
-Adblocker host files as published all over the net should work just fine.
+Adblocker hosts files as published all over the net should work just fine.
 
 * Blocking IPv6 requests by default and responding with NXDOMAIN.
 Use --ipv6 option to overwrite the default.

--- a/src/fdns/fdns.h
+++ b/src/fdns/fdns.h
@@ -73,7 +73,7 @@ static inline int check_addr_port(const char *str) {
 #define PATH_RUN_FDNS "/run/fdns"
 #define PATH_ETC_TRACKERS_LIST (SYSCONFDIR "/trackers")
 #define PATH_ETC_ADBLOCKER_LIST (SYSCONFDIR "/adblocker")
-#define PATH_ETC_HOST_LIST (SYSCONFDIR "/host")
+#define PATH_ETC_HOSTS_LIST (SYSCONFDIR "/hosts")
 #define PATH_ETC_SERVER_LIST (SYSCONFDIR "/servers")
 #define PATH_ETC_WORKER_SECCOMP (SYSCONFDIR "/worker.seccomp")
 #define PATH_LOG_FILE "/var/log/fdns.log"

--- a/src/fdns/main.c
+++ b/src/fdns/main.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
 			 else if (strncmp(argv[i], "--test-url=", 11) == 0) {
 			 	dnsfilter_load_list(PATH_ETC_TRACKERS_LIST);
 			 	dnsfilter_load_list(PATH_ETC_ADBLOCKER_LIST);
-			 	dnsfilter_load_list(PATH_ETC_HOST_LIST);
+			 	dnsfilter_load_list(PATH_ETC_HOSTS_LIST);
 			 	dnsfilter_test(argv[i] + 11);
 			 	return 0;
 			 }

--- a/src/fdns/worker.c
+++ b/src/fdns/worker.c
@@ -34,7 +34,7 @@ void worker(void) {
 	if (!arg_nofilter) {
 		dnsfilter_load_list(PATH_ETC_TRACKERS_LIST);
  		dnsfilter_load_list(PATH_ETC_ADBLOCKER_LIST);
- 		dnsfilter_load_list(PATH_ETC_HOST_LIST);
+ 		dnsfilter_load_list(PATH_ETC_HOSTS_LIST);
  	}
 
 	// connect SSL/DNS server

--- a/src/man/fdns.txt
+++ b/src/man/fdns.txt
@@ -72,7 +72,7 @@ Start the stats monitor. Run this command as a regular user in a terminal.
 $ fdns --monitor
 .TP
 \fB\-\-nofilter
-No DNS request filtering. This disables the adblocker, the tracker filter, and the user host file
+No DNS request filtering. This disables the adblocker, the tracker filter, and the user hosts file
 installed in /etc/fdns directory.
 .TP
 \fB\-\-proxy-addr=address
@@ -221,7 +221,7 @@ $ sudo pkill fdns
 .SH FILES
 /etc/fdns/adblocker - adblocker filter distributed with fdns
 .br
-/etc/fdns/host - user host file
+/etc/fdns/hosts - user hosts file
 .br
 /etc/fdns/trackers - tracker filter distributed with fdns
 


### PR DESCRIPTION
IMHO I think it's more intuitive to use **hosts** file instead of **host** file, cfr. /etc/hosts.