### PR TITLE
fix server load_file() overwriting global list

### DIFF
--- a/src/fdns/server.c
+++ b/src/fdns/server.c
@@ -419,6 +419,12 @@ static int load_file(const char *fname) {
 
 	int linecnt = 0; // line counter
 	DnsServer **ptr = &slist;
+
+	// go to the end of the list
+	while (*ptr != NULL) {
+		ptr = &(*ptr)->next;
+	}
+
 	while (1) {
 		DnsServer *s = read_one_server(fp, &linecnt, fname);
 		if (!s)


### PR DESCRIPTION
The `load_file()` function overrides the global slist variable and thus looses previously loaded servers. This both creates a memory leak and prevents the use of `/etc/fdns/servers.local config`.