### PR TITLE
Update servers

### DIFF
--- a/etc/servers
+++ b/etc/servers
@@ -1549,7 +1549,7 @@ name: nwps-family
 website:https://niko.nwps.fi
 tags: h2ping, family, Finaland, Europe
 address: 95.217.11.63:443
-host: family.ns.nwps.fi/dns-query
+host: kids.ns.nwps.fi/dns-query
 keepalive: 7
 end;
 
@@ -1558,14 +1558,6 @@ website:https://niko.nwps.fi
 tags: h2ping, adblocker, Finaland, Europe
 address: 95.217.11.63:443
 host: public.ns.nwps.fi/dns-query
-keepalive: 7
-end;
-
-name: nwps-unfiltered
-website:https://niko.nwps.fi
-tags: h2ping, Finaland, Europe
-address: 95.217.11.63:443
-host: unfiltered.ns.nwps.fi/dns-query
 keepalive: 7
 end;
 


### PR DESCRIPTION
nwps-family host is "kids.ns.nwps.fi", not "family.ns.nwps.fi". nwps-unfiltered does not exist anymore.